### PR TITLE
add events and news to decap

### DIFF
--- a/_news/2023-09-23-processing-community-catalog-reading.md
+++ b/_news/2023-09-23-processing-community-catalog-reading.md
@@ -7,6 +7,8 @@ start_date: 2023-09-23
 end_date: 2023-09-23
 event_title: Processing Community Catalog Reading
 main_image: /assets/img/events/2023-09-23-processing-community-catalog-reading/an-introduction-by-casey-reas.webp
+featured_caption: Casey Reas talking to the audience. A large Processing
+  Community Catalog projected behind him.
 images:
   - image: /assets/img/events/2023-09-23-processing-community-catalog-reading/casey-reas-and-olivia-jack.webp
     caption: Casey Reas and Olivia Jack

--- a/_news/2023-09-23-processing-community-catalog-reading.md
+++ b/_news/2023-09-23-processing-community-catalog-reading.md
@@ -7,14 +7,14 @@ start_date: 2023-09-23
 end_date: 2023-09-23
 event_title: Processing Community Catalog Reading
 main_image: /assets/img/events/2023-09-23-processing-community-catalog-reading/an-introduction-by-casey-reas.webp
-images: 
-  - file: /assets/img/events/2023-09-23-processing-community-catalog-reading/casey-reas-and-olivia-jack.webp
+images:
+  - image: /assets/img/events/2023-09-23-processing-community-catalog-reading/casey-reas-and-olivia-jack.webp
     caption: Casey Reas and Olivia Jack
-  - file: /assets/img/events/2023-09-23-processing-community-catalog-reading/so-kanno-and-omii-chen.webp
+  - image: /assets/img/events/2023-09-23-processing-community-catalog-reading/so-kanno-and-omii-chen.webp
     caption: So Kanno and Omii Chen
-  - file: /assets/img/events/2023-09-23-processing-community-catalog-reading/rachel-uwa.webp
+  - image: /assets/img/events/2023-09-23-processing-community-catalog-reading/rachel-uwa.webp
     caption: Rachel Uwa
-  - file: /assets/img/events/2023-09-23-processing-community-catalog-reading/processing-community-catalog.jpeg
+  - image: /assets/img/events/2023-09-23-processing-community-catalog-reading/processing-community-catalog.jpeg
     caption: Processing Community Catalog
 publish_date: 2023-09-23
 tags: portfolio

--- a/_news/2024-08-26-open-call.md
+++ b/_news/2024-08-26-open-call.md
@@ -11,22 +11,17 @@ images:
     caption: Unit 3 available for rent
 tags: call
 ---
-
 <video width="720" height="1280" controls>
   <source src="{{ "/assets/video/open_call_august_2024_low.mp4" | relative_url }}" type="video/mp4">
   Your browser does not support the video tag.
 </video>
-<br>
 
 You'll be joining a group of multidisciplinary artists.
-[Explore who we are.]({{ site.baseurl }}/people.html)
-<br><br>
+[Explore who we are](/people.html).
+
 The open space (area: 342 m<sup>2</sup>) is divided in a total of 10 ateliers.
-<br><br>
 
 ### The available areas are:
 
-<ul>
-<li><b>Unit 1</b> - 378.52 €/month, 14.8 m<sup>2</sup> in total shared (to be shared with another artist)</li>
-<li><b>Unit 3</b> - 417.93 €/month, 18.2 m<sup>2</sup>, can host a maximum of 3 people</li>
-</ul>
+* **Unit 1** - 378.52 €/month, 14.8 m² in total shared (to be shared with another artist)
+* **Unit 3** - 417.93 €/month, 18.2 m², can host a maximum of 3 people

--- a/_news/2024-08-26-open-call.md
+++ b/_news/2024-08-26-open-call.md
@@ -3,6 +3,7 @@ layout: call
 title: Open Call for New Tenant Artists
 subtitle: 
 description: We’re looking for someone to join us at Prachtsaal Studio, our beautiful open space in Neukölln (halfway between U-Leinestraße and U-Hermannstraße)!
+publish_date: 2024-08-26
 images: 
   - file: /assets/img/news/unit1.webp
     caption: Half of Unit 1 available for rent

--- a/_news/2024-08-26-open-call.md
+++ b/_news/2024-08-26-open-call.md
@@ -4,10 +4,10 @@ title: Open Call for New Tenant Artists
 subtitle: 
 description: We’re looking for someone to join us at Prachtsaal Studio, our beautiful open space in Neukölln (halfway between U-Leinestraße and U-Hermannstraße)!
 publish_date: 2024-08-26
-images: 
-  - file: /assets/img/news/unit1.webp
+images:
+  - image: /assets/img/news/unit1.webp
     caption: Half of Unit 1 available for rent
-  - file: /assets/img/news/unit3.webp
+  - image: /assets/img/news/unit3.webp
     caption: Unit 3 available for rent
 tags: call
 ---

--- a/_news/2024-12-06-the-art-market.md
+++ b/_news/2024-12-06-the-art-market.md
@@ -9,9 +9,9 @@ start_date: 2024-12-06
 end_date: 2024-12-08
 event_title: The Art Market
 images: 
-  - file: /assets/img/events/2024-12-06-the-art-market/20231202_173014_Original-scaled.webp
-  - file: /assets/img/events/2024-12-06-the-art-market/20231202_175128_Original-768x1024.webp
-  - file: /assets/img/events/2024-12-06-the-art-market/20231202_175141_Original-768x1024.webp
+  - image: /assets/img/events/2024-12-06-the-art-market/20231202_173014_Original-scaled.webp
+  - image: /assets/img/events/2024-12-06-the-art-market/20231202_175128_Original-768x1024.webp
+  - image: /assets/img/events/2024-12-06-the-art-market/20231202_175141_Original-768x1024.webp
 ---
 
 

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -35,8 +35,8 @@ collections:
     label: "Events" # Used in the UI
     identifier_field: title
     folder: "_events" # The path to the folder where the documents are stored
-    media_folder: '../{{media_folder}}/events/{{slug}}/'
-    public_folder: '/assets/img/events/{{slug}}/'
+    media_folder: '../{{media_folder}}/events/{{start_date}}-{{slug}}/'
+    public_folder: '/assets/img/events/{{start_date}}-{{slug}}/'
     create: true # Allow users to create new documents in this collection
     slug: "{{start_date}}-{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md
     fields: # The fields for each document, usually in front matter
@@ -87,6 +87,75 @@ collections:
         required: false
         multiple: true
         options: ["portfolio"]
+        
+      - label: "Body"
+        name: "body"
+        widget: "markdown"
+        required: false 
+
+  - name: "news" # Used in routes, e.g., /admin/collections/news
+    label: "News" # Used in the UI
+    identifier_field: title
+    folder: "_news" # The path to the folder where the documents are stored
+    media_folder: '../{{media_folder}}/events/{{start_date}}-{{event_title}}/'
+    public_folder: '/assets/img/events/{{start_date}}-{{event_title}}/'
+    create: true # Allow users to create new documents in this collection
+    slug: "{{publish_date}}-{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md
+    fields: # The fields for each document, usually in front matter
+      - label: "Layout" 
+        name: "layout"
+        hidden: true
+        default: "event" 
+      
+      - label: "Title"
+        name: "title"
+        widget: "string" 
+      
+      - label: "Subtitle"
+        name: "subtitle"
+        widget: "string"
+        required: false
+      
+      - label: "Description"
+        name: "description"
+        widget: "string"
+        required: false
+      
+      - label: "Publish Date"
+        name: "publish_date"
+        widget: "datetime" 
+        date_format: "YYYY-MM-DD"
+        default: "{{now}}"
+
+      - label: "Event Title"
+        name: "event_title"
+        widget: "string" 
+      - label: "Event Start Date"
+        name: "start_date"
+        widget: "datetime" 
+        date_format: "YYYY-MM-DD"
+      - label: "Event End Date"
+        name: "end_date"
+        widget: "datetime" 
+        date_format: "YYYY-MM-DD"
+
+      - label: "Featured Image"
+        name: "main_image"
+        widget: "image"
+        required: false
+      
+      - label: "Images"
+        name: "images" 
+        widget: "list"
+        required: false
+        fields: 
+          - {label: Image, name: image, widget: image}
+          - {label: Caption, name: caption, widget: string}
+    
+      - label: "Tags"
+        name: "tags"
+        widget: "hidden"
+        default: "news"
         
       - label: "Body"
         name: "body"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -143,6 +143,11 @@ collections:
         name: "main_image"
         widget: "image"
         required: false
+
+      - label: "Featured caption"
+        name: "featured_caption"
+        widget: string
+        required: false
       
       - label: "Images"
         name: "images" 

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -30,6 +30,69 @@ collections:
         fields: 
           - {label: Title, name: title, widget: string}
           - {label: Body, name: body, widget: markdown}
+
+  - name: "events" # Used in routes, e.g., /admin/collections/events
+    label: "Events" # Used in the UI
+    identifier_field: title
+    folder: "_events" # The path to the folder where the documents are stored
+    media_folder: '../{{media_folder}}/events/{{slug}}/'
+    public_folder: '/assets/img/events/{{slug}}/'
+    create: true # Allow users to create new documents in this collection
+    slug: "{{start_date}}-{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md
+    fields: # The fields for each document, usually in front matter
+      - label: "Layout" 
+        name: "layout"
+        hidden: true
+        default: "event" 
+      
+      - label: "Title"
+        name: "title"
+        widget: "string" 
+      
+      - label: "Subtitle"
+        name: "subtitle"
+        widget: "string"
+        required: false
+      
+      - label: "Description"
+        name: "description"
+        widget: "string"
+        required: false
+      
+      - label: "Start Date"
+        name: "start_date"
+        widget: "datetime" 
+        date_format: "YYYY-MM-DD"
+      - label: "End Date"
+        name: "end_date"
+        widget: "datetime" 
+        date_format: "YYYY-MM-DD"
+
+      - label: "Featured Image"
+        name: "main_image"
+        widget: "image"
+        required: false
+      
+      - label: "Images"
+        name: "images" 
+        widget: "list"
+        required: false
+        fields: 
+          - {label: Image, name: image, widget: image}
+          - {label: Caption, name: caption, widget: string}
+    
+      - label: "Tags"
+        name: "tags"
+        widget: "select"
+        required: false
+        multiple: true
+        options: ["portfolio"]
+        
+      - label: "Body"
+        name: "body"
+        widget: "markdown"
+        required: false 
+
   - name: "members" # Used in routes, e.g., /admin/collections/members
     label: "Members" # Used in the UI
     identifier_field: full_name
@@ -106,39 +169,3 @@ collections:
         widget: "markdown", 
         required: false 
       }
-
-  # - name: "events" # Used in routes, e.g., /admin/collections/blog
-  #   label: "Events" # Used in the UI
-  #   folder: "events/_posts" # The path to the folder where the documents are stored
-  #   create: true # Allow users to create new documents in this collection
-  #   slug: "{{year}}-{{month}}-{{day}}-{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md
-  #   fields: # The fields for each document, usually in front matter
-  #     - { label: "Layout", name: "layout", widget: "hidden", default: "event" }
-  #     - { label: "Title", name: "title", widget: "string" }
-  #     - { label: "Subtitle", name: "subtitle", widget: "string" }
-  #     - { label: "Main Image", name: "main_image", widget: "image" }
-  #     - { label: "Description", name: "description", widget: "string" }
-  #     - { label: "Start Date", name: "start_date", widget: "string" }
-  #     - { label: "Quote", name: "quote", widget: "string" }
-  #     - { label: "Quote Author", name: "quote_author", widget: "string" }
-  #     - { label: "Quote Author Role", name: "quote_author_role", widget: "string" }
-  #     - { label: "Images", name: "images", widget: "object" }
-  #       - { label: "File", name: "images", widget: "object" }
-  #       - { label: "Caption", name: "images", widget: "object" }
-  #     - { label: "Link", name: "link", widget: "string" }
-  #     - { label: "Link Text", name: "link_text", widget: "string" }
-  #     - { label: "Tags", name: "tags", widget: "string" }
-  #     - { label: "Body", name: "body", widget: "markdown" }
-
-  # - name: "news" # Used in routes, e.g., /admin/collections/blog
-  #   label: "News" # Used in the UI
-  #   folder: "news/_posts" # The path to the folder where the documents are stored
-  #   create: true # Allow users to create new documents in this collection
-  #   slug: "{{year}}-{{month}}-{{day}}-{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md
-  #   fields: # The fields for each document, usually in front matter
-  #     - { label: "Layout", name: "layout", widget: "hidden", default: "blog" }
-  #     - { label: "Title", name: "title", widget: "string" }
-  #     - { label: "Publish Date", name: "date", widget: "datetime" }
-  #     - { label: "Featured Image", name: "thumbnail", widget: "image" }
-  #     - { label: "Rating (scale of 1-5)", name: "rating", widget: "number" }
-  #     - { label: "Body", name: "body", widget: "markdown" }

--- a/events.html
+++ b/events.html
@@ -10,7 +10,8 @@ add-js: future_events.js
 </header>
 
 {% assign portfolio_events = site.documents | where: "tags", "portfolio" %}
-{% capture now_seconds %}{{'now' | date: '%s'}}{% endcapture %}
+{% capture yesterday_seconds %}{{ site.time | date: '%s' | minus: 86400 }}{% endcapture %}
+<!-- use yesterday seconds, since todays time is greater than time 0, and we want an event with today's date with time 0 to appear -->
 
 <div class="flex justify-center mb-28">
 
@@ -25,7 +26,7 @@ add-js: future_events.js
         {% capture date_string %}{{event.start_date | date: "%d.%m.%Y"}} - {{event.end_date | date: "%d.%m.%Y"}}{% endcapture %}
         {% endif %}
         
-        {% if event_seconds >= now_seconds %}
+        {% if event_seconds >= yesterday_seconds %}
         
         <div future-date="{{ event_date }}" class="w-full max-w-64 lg:w-64 links-without-underline">
             <div class="font-prachtsaal text-right text-sm">{{ date_string }}</div>


### PR DESCRIPTION
events and news are now editable on decap with this PR.
note that news items are displayed by publish_date, but to be able to refer to event media, the start_date and event_title are also included in the metadata, so that the same media folder as an event can be referred to in a news item. note that if you want to access the media for an existing event, you'll need to create the news item, and then edit it again to see the media.